### PR TITLE
Fix ER Diagram breakage for FKs to tables needing quoted names

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/ERDTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/ERDTab.vue
@@ -126,7 +126,7 @@ export default {
             {
               data: {
                 id: node.id,
-                html_id: node.id.replace(/[^a-zA-Z_.-:]+/, '_'),
+                html_id: node.id.replace(/[^a-zA-Z0-9_-]+/g, '_'),
                 label: node.label,
                 columns: node.columns.map((column) => (
                   {
@@ -200,7 +200,7 @@ export default {
             group: 'nodes',
             data: {
               id: node.id,
-              html_id: node.id.replace(/[^a-zA-Z_.-:]+/, '_'),
+              html_id: node.id.replace(/[^a-zA-Z0-9_-]+/g, '_'),
               label: node.label,
               columns: node.columns.map((column) => (
                   {

--- a/pgmanage/app/tests/test_draw_graph_sqlite.py
+++ b/pgmanage/app/tests/test_draw_graph_sqlite.py
@@ -1,0 +1,125 @@
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import app.include.OmniDatabase as OmniDatabase
+from app.models.main import Connection, Technology
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+
+from .utils_testing import execute_client_login, get_client_omnidb_session
+
+User = get_user_model()
+
+
+class DrawGraphSQLite(TestCase):
+    """ER Diagram generation against a throwaway SQLite database file.
+
+    SQLite is the only backend whose QueryTables returns name_raw (always
+    quoted, for every table) while its foreign-key metadata carries unquoted
+    table names, so these tests cover the label-based edge endpoint
+    resolution in draw_graph. No live database server is required.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        fd, cls.db_path = tempfile.mkstemp(
+            suffix='.db', prefix='pgmanage_erd_test_'
+        )
+        os.close(fd)
+
+        # draw_graph resolves the saved ERD layout by treating database_index
+        # as a Connection id; the session below posts database_index 0, so a
+        # Connection row with that id must exist for the request to succeed.
+        cls.test_connection = Connection.objects.create(
+            id=0,
+            user=User.objects.get(username="admin"),
+            technology=Technology.objects.filter(name="sqlite").first(),
+            database=cls.db_path,
+            alias="ERD sqlite test",
+        )
+        cls.database = OmniDatabase.Generic.InstantiateDatabase(
+            'sqlite',
+            '',
+            '',
+            cls.db_path,
+            '',
+            '',
+            cls.test_connection.id
+        )
+        cls.database.connection.Execute(
+            'CREATE TABLE "TestTable882" (id integer PRIMARY KEY)'
+        )
+        cls.database.connection.Execute(
+            'CREATE TABLE child_882 ('
+            'id integer PRIMARY KEY, '
+            'parent_id integer REFERENCES "TestTable882" (id))'
+        )
+
+        cls.client_session = Client()
+        success, response = execute_client_login(
+            p_client=cls.client_session, p_username='admin', p_password='admin'
+        )
+        get_client_omnidb_session(p_client=cls.client_session)
+        assert 200 == response.status_code
+
+        session = cls.client_session.session
+        session['pgmanage_session'].databases = [{
+            'database': cls.database,
+            'prompt_password': False,
+            'prompt_timeout': datetime.now() + timedelta(0, 60000)
+        }]
+        session['pgmanage_session'].tab_connections = {0: cls.database}
+        session['pgmanage_session'].tabs_databases = {0: cls.db_path}
+        session.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            os.remove(cls.db_path)
+        except OSError:
+            pass
+        super().tearDownClass()
+
+    def test_draw_graph_sqlite_fk_edges_session(self):
+        # The SQLite ERD tab is opened without a schema (see createERDTab()
+        # in TreeSqlite.vue), so the frontend posts an empty schema string.
+        response = self.client_session.post(
+            '/draw_graph/',
+            {'data': '{"database_index": 0, "workspace_id": 0, "schema": ""}'},
+        )
+        assert 200 == response.status_code
+        data = json.loads(response.content.decode())
+
+        labels = {node['label']: node for node in data['nodes']}
+        assert 'TestTable882' in labels
+        assert 'child_882' in labels
+
+        # every edge endpoint must reference an existing node
+        node_ids = {node['id'] for node in data['nodes']}
+        for edge in data['edges']:
+            assert edge['from'] in node_ids, \
+                "edge source {!r} is not a known node".format(edge['from'])
+            assert edge['to'] in node_ids, \
+                "edge target {!r} is not a known node".format(edge['to'])
+
+        # the FK edge is present even though SQLite reports unquoted table
+        # names in its foreign-key metadata while node ids are quoted
+        child_id = labels['child_882']['id']
+        parent_id = labels['TestTable882']['id']
+        assert any(
+            edge['from'] == child_id and edge['to'] == parent_id
+            for edge in data['edges']
+        ), 'expected FK edge child_882 -> TestTable882 in graph'
+
+        # the FK/PK column flags are resolved despite the name mismatch
+        assert any(
+            column['name'] == 'parent_id' and column['is_fk']
+            for column in labels['child_882']['columns']
+        ), 'expected parent_id to be flagged as a foreign key column'
+        assert any(
+            column['name'] == 'id' and column['is_pk']
+            for column in labels['TestTable882']['columns']
+        ), 'expected TestTable882.id to be flagged as a primary key column'

--- a/pgmanage/app/tests/test_postgresql12.py
+++ b/pgmanage/app/tests/test_postgresql12.py
@@ -1486,3 +1486,45 @@ CREATE MATERIALIZED VIEW public.mvw_omnidb_test AS
     def test_get_object_description_postgresql_nosession(self):
         response = self.client_nosession.post('/get_object_description_postgresql/', {'data': '{"database_index": 0, "workspace_id": 0}'})
         assert 401 == response.status_code
+
+    def test_draw_graph_uppercase_fk_target_postgresql_session(self):
+        # Regression test for issue #882: a foreign key referencing a table whose
+        # name requires quoting (e.g. contains uppercase characters) must not
+        # produce a graph edge that points at a non-existent node, which broke
+        # ER Diagram rendering with 'Can not create edge with nonexistant target'.
+        conn = self.database.connection
+        conn.Execute('CREATE SCHEMA IF NOT EXISTS "erd_test_882"')
+        try:
+            conn.Execute('CREATE TABLE "erd_test_882"."TestTable882" (id integer PRIMARY KEY)')
+            conn.Execute(
+                'CREATE TABLE "erd_test_882"."child_882" ('
+                'id integer PRIMARY KEY, '
+                'parent_id integer REFERENCES "erd_test_882"."TestTable882" (id))'
+            )
+
+            response = self.client_session.post(
+                '/draw_graph/',
+                {'data': '{"database_index": 0, "workspace_id": 0, "schema": "erd_test_882"}'},
+            )
+            assert 200 == response.status_code
+            data = json.loads(response.content.decode())
+
+            node_ids = {node['id'] for node in data['nodes']}
+            # both tables are present as nodes; the uppercase name is quoted
+            assert '"TestTable882"' in node_ids
+            assert 'child_882' in node_ids
+
+            # every edge endpoint must reference an existing node (no dangling target)
+            for edge in data['edges']:
+                assert edge['from'] in node_ids, \
+                    "edge source {!r} is not a known node".format(edge['from'])
+                assert edge['to'] in node_ids, \
+                    "edge target {!r} is not a known node".format(edge['to'])
+
+            # the foreign key edge pointing at the uppercase table is present
+            assert any(
+                edge['from'] == 'child_882' and edge['to'] == '"TestTable882"'
+                for edge in data['edges']
+            ), 'expected FK edge child_882 -> "TestTable882" in graph'
+        finally:
+            conn.Execute('DROP SCHEMA IF EXISTS "erd_test_882" CASCADE')

--- a/pgmanage/app/tests/test_postgresql12.py
+++ b/pgmanage/app/tests/test_postgresql12.py
@@ -1493,6 +1493,20 @@ CREATE MATERIALIZED VIEW public.mvw_omnidb_test AS
         # produce a graph edge that points at a non-existent node, which broke
         # ER Diagram rendering with 'Can not create edge with nonexistant target'.
         conn = self.database.connection
+        # draw_graph resolves the saved ERD layout by treating database_index
+        # as a Connection id; the class fixture posts database_index 0, so a
+        # Connection row with that id must exist for the request to succeed.
+        Connection.objects.create(
+            id=0,
+            user=User.objects.get(username="admin"),
+            technology=Technology.objects.filter(name=self.db_type).first(),
+            server=self.host,
+            port=self.port,
+            database=self.service,
+            username=self.role,
+            password=self.encrypted_password,
+            alias="ERD layout lookup (issue #882)",
+        )
         conn.Execute('CREATE SCHEMA IF NOT EXISTS "erd_test_882"')
         try:
             conn.Execute('CREATE TABLE "erd_test_882"."TestTable882" (id integer PRIMARY KEY)')

--- a/pgmanage/app/views/workspace.py
+++ b/pgmanage/app/views/workspace.py
@@ -236,8 +236,15 @@ def draw_graph(request, database):
         tables = database.QueryTables(False, schema)
 
         for table in tables.Rows:
+            # Use the quoted identifier (name_raw) as the node id so it matches
+            # the quote_ident()-formatted table names returned for foreign keys.
+            # Otherwise nodes and FK edges disagree for names that require
+            # quoting (e.g. uppercase), producing edges that point at a
+            # non-existent node. Fall back to table_name for backends that don't
+            # provide name_raw.
+            node_id = table.get('name_raw') or table["table_name"]
             node_data = {
-                "id": table["table_name"],
+                "id": node_id,
                 "label": table["table_name"],
                 "group": 1,
                 "columns": []
@@ -255,15 +262,21 @@ def draw_graph(request, database):
                 'is_fk': False,
                 } for c in table_columns))
 
-            node_dict[table["table_name"]] = node_data
+            node_dict[node_id] = node_data
 
         q_fks = database.QueryTablesForeignKeys(None, False, schema)
 
         for fk in q_fks.Rows:
-            # ensure that the new edge stays within the same schema and points to an existing table
+            # ensure that the new edge stays within the same schema and that both
+            # endpoints reference an existing node; otherwise the graph would
+            # contain an edge pointing at a non-existent node and fail to render
             # table partitions are *not* included in the node list
             # FIXME: resolve FKs of partitioned table from its partitions
-            if fk["r_table_schema"] == schema and fk["table_name"] in node_dict.keys():
+            if (
+                fk["r_table_schema"] == schema
+                and fk["table_name"] in node_dict
+                and fk["r_table_name"] in node_dict
+            ):
                 edge_dict[fk["constraint_name"]] = {
                     "from": fk["table_name"],
                     "to": fk["r_table_name"],

--- a/pgmanage/app/views/workspace.py
+++ b/pgmanage/app/views/workspace.py
@@ -266,20 +266,30 @@ def draw_graph(request, database):
 
         q_fks = database.QueryTablesForeignKeys(None, False, schema)
 
+        # Some backends return unquoted table names in their foreign-key
+        # metadata while name_raw is quoted (e.g. SQLite), so an endpoint may
+        # not be a node id itself; fall back to the unquoted display label.
+        node_ids_by_label = {
+            node["label"]: node_id for node_id, node in node_dict.items()
+        }
+
+        def resolve_node_id(name):
+            if name in node_dict:
+                return name
+            return node_ids_by_label.get(name)
+
         for fk in q_fks.Rows:
             # ensure that the new edge stays within the same schema and that both
             # endpoints reference an existing node; otherwise the graph would
             # contain an edge pointing at a non-existent node and fail to render
             # table partitions are *not* included in the node list
             # FIXME: resolve FKs of partitioned table from its partitions
-            if (
-                fk["r_table_schema"] == schema
-                and fk["table_name"] in node_dict
-                and fk["r_table_name"] in node_dict
-            ):
+            from_id = resolve_node_id(fk["table_name"])
+            to_id = resolve_node_id(fk["r_table_name"])
+            if fk["r_table_schema"] == schema and from_id and to_id:
                 edge_dict[fk["constraint_name"]] = {
-                    "from": fk["table_name"],
-                    "to": fk["r_table_name"],
+                    "from": from_id,
+                    "to": to_id,
                     "from_col": None,
                     "to_col": None,
                     "label": "",
@@ -294,8 +304,8 @@ def draw_graph(request, database):
             edge['from_col'] = fkcol['column_name']
             edge['to_col'] = fkcol['r_column_name']
             edge['cgid'] = cgid
-            table = node_dict.get(fkcol['table_name'])
-            r_table = node_dict.get(fkcol['r_table_name'])
+            table = node_dict.get(resolve_node_id(fkcol['table_name']))
+            r_table = node_dict.get(resolve_node_id(fkcol['r_table_name']))
             if table and r_table:
                 for col in table['columns']:
                     if col['name'] == fkcol['column_name']:


### PR DESCRIPTION
ER Diagram generation failed with "Can not create edge with nonexistant
target" whenever a foreign key referenced a table whose name required
quoting (e.g. contained uppercase characters).

**Root cause:** `draw_graph()` keyed graph nodes by the raw, unquoted table
name from `QueryTables`, but built foreign-key edges from
`QueryTablesForeignKeys`, which returns names via `quote_ident()`. For names
needing quotes the node id (`Testtable`) and the edge target (`"Testtable"`)
diverged, so Cytoscape could not find the target node and aborted rendering.

**Fix:**
- Key nodes by the quoted identifier (`name_raw`), keep the unquoted name as
  the display label, and only create an edge when both endpoints reference an
  existing node.
- Resolve FK edge endpoints by falling back to the unquoted display label
  when the FK metadata name is not a node id itself — needed because SQLite
  returns `name_raw` quoted for every table while its FK pragma metadata is
  unquoted. This also fixes the `is_fk`/`is_pk` column-flag lookups.
- Fix `html_id` generation in the ERD tab: the sanitizing regex lacked the
  global flag, so a quoted node id kept its trailing quote and
  `document.querySelector()` in `adjustSizes()` threw on the invalid
  selector, skipping the layout run.

**Testing:** adds regression tests for PostgreSQL (live server) and SQLite
(temp file, no server needed). Both fail without their respective fixes and
pass with them.

**Note:** ERD layouts saved before this change store unquoted node ids, so
tables whose names require quoting lose their saved position once after
upgrading (they reappear via `new_nodes`); positions of all other tables are
preserved.

Fixes #882
